### PR TITLE
CRUD（Store）保存処理

### DIFF
--- a/umarche/MULTILOGIN.md
+++ b/umarche/MULTILOGIN.md
@@ -766,20 +766,40 @@ php artisan serve
 </div>
 ```
 
-## sec117 登録する処理
+## sec117 登録する処理 - CRUD(Store)
 - 前回まではcreate画面でフォームを用意した。
 - 今回は登録するボタンで登録処理を行う。
 - Formタグ、method="post" action=store 指定
 - @csrf 必須
 - 戻るボタンは type="button"をつけておく
 - inputタグ name="" 属性を
-Request $requestインスタンスで取得
+Request $request インスタンスで取得
 dd($request->name);
-
-
-1\.
-```
-```
+- 保存する際にバリデーション機能を追加。
+- 1. View
+バリデーションで画面読み込み後も入力した値を保持したい場合
+- <input name="email" value="{{ old('email') }}">
+- 2. Model - プロパティで必要な情報を指定する必要がある。
+$fillable or $guarded で設定
+- procted $fillable = [
+    'name',
+    'email',
+    'password',
+];
+- 3. Controller - バリデーション設定
+簡易バリデーション or カスタムリクエスト
+- $request->validate([
+    'name' => 'required|string|max:255',
+    'email' => 'required|string|email|max:255|unique:owners',
+    'password' => 'required|string|confirmed|min:8',
+]);
+- 4. Controller - 保存処理
+Owner::create([
+    'name' => $request->name,
+    'email' => $request->email,
+    'password' => Hash::make($request->password),
+]);
+return redirect()->route('admin.owners.index'); 
 
 
 1\.

--- a/umarche/app/Http/Controllers/Admin/Auth/RegisteredUserController.php
+++ b/umarche/app/Http/Controllers/Admin/Auth/RegisteredUserController.php
@@ -31,9 +31,9 @@ class RegisteredUserController extends Controller
     public function store(Request $request): RedirectResponse
     {
         $request->validate([
-            'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:admins'],
-            'password' => ['required', 'confirmed', Rules\Password::defaults()],
+            'name' => 'required|string|max:255',
+            'email' => 'required|string|email|max:255|unique:owners',
+            'password' => 'required|string|confirmed|min:8',
         ]);
 
         $user = Admin::create([

--- a/umarche/app/Http/Controllers/Admin/OwnersController.php
+++ b/umarche/app/Http/Controllers/Admin/OwnersController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use App\Models\Owner; // Eloquent エロクアント
 use Illuminate\Support\Facades\DB; // QueryBuilder クエリビルダ
 use Carbon\Carbon; // カーボンライブラリ
+use Illuminate\Support\Facades\Hash;
 
 class OwnersController extends Controller
 {
@@ -54,7 +55,19 @@ class OwnersController extends Controller
      */
     public function store(Request $request)
     {
-        //
+        $request->validate([
+            'name' => 'required|string|max:255',
+            'email' => 'required|string|email|max:255|unique:owners',
+            'password' => 'required|string|confirmed|min:8',
+        ]);
+
+        Owner::create([
+            'name' => $request->name,
+            'email' => $request->email,
+            'password' => Hash::make($request->password),
+        ]);
+
+        return redirect()->route('admin.owners.index');
     }
 
     /**

--- a/umarche/config/auth.php
+++ b/umarche/config/auth.php
@@ -117,19 +117,19 @@ return [
     'passwords' => [
         'users' => [
             'provider' => 'users',
-            'table' => 'password_reset_tokens',
+            'table' => 'password_resets',
             'expire' => 60,
             'throttle' => 60,
         ],
         'owners' => [
             'provider' => 'owners',
-            'table' => 'owner_password_reset_tokens',
+            'table' => 'owner_password_resets',
             'expire' => 60,
             'throttle' => 60,
         ],
         'admin' => [
             'provider' => 'admin',
-            'table' => 'admin_password_reset_tokens',
+            'table' => 'admin_password_resets',
             'expire' => 60,
             'throttle' => 60,
         ],

--- a/umarche/resources/views/admin/owners/create.blade.php
+++ b/umarche/resources/views/admin/owners/create.blade.php
@@ -15,37 +15,41 @@
                             <h1 class="sm:text-3xl text-2xl font-medium title-font mb-4 text-gray-900">オーナー登録</h1>
                           </div>
                           <div class="lg:w-1/2 md:w-2/3 mx-auto">
-                            <div class="-m-2">
-                              <div class="p-2 w-1/2 mx-auto">
-                                <div class="relative">
-                                  <label for="name" class="leading-7 text-sm text-gray-600">オーナー名</label>
-                                  <input type="text" id="name" name="name" required class="w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out">
+                            <div class="mb-4" :errors="$errors" />
+                            <form method="post" action="{{ route('admin.owners.store')}}">
+                              @csrf
+                              <div class="-m-2">
+                                <div class="p-2 w-1/2 mx-auto">
+                                  <div class="relative">
+                                    <label for="name" class="leading-7 text-sm text-gray-600">オーナー名</label>
+                                    <input type="text" id="name" name="name" value="{{ old('name')}}" required class="w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out">
+                                  </div>
+                                </div>
+                                <div class="p-2 w-1/2 mx-auto">
+                                  <div class="relative">
+                                    <label for="email" class="leading-7 text-sm text-gray-600">メールアドレス</label>
+                                    <input type="email" id="email" name="email" value="{{ old('email')}}" required class="w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out">
+                                  </div>
+                                </div>
+                                <div class="p-2 w-1/2 mx-auto">
+                                  <div class="relative">
+                                    <label for="password" class="leading-7 text-sm text-gray-600">パスワード</label>
+                                    <input type="password" id="password" name="password" required class="w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out">
+                                  </div>
+                                </div>
+                                <div class="p-2 w-1/2 mx-auto">
+                                  <div class="relative">
+                                    <label for="password_confirmation" class="leading-7 text-sm text-gray-600">パスワード確認</label>
+                                    <input type="password" id="password_confirmation" name="password_confirmation" required class="w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out">
+                                  </div>
+                                </div>
+                                <div class="p-2 w-full flex justify-around mt-4">
+                                  <button type="button" onclick="location.href='{{ route('admin.owners.index')}}'" class="bg-gray-200 border-0 py-2 px-8 focus:outline-none hover:bg-igray-400 rounded text-lg">戻る</button>
+                                  <button type="submit" class="bg-indigo-500 border-0 py-2 px-8 focus:outline-none hover:bg-indigo-600 rounded text-lg">登録する</button>
                                 </div>
                               </div>
-                              <div class="p-2 w-1/2 mx-auto">
-                                <div class="relative">
-                                  <label for="email" class="leading-7 text-sm text-gray-600">メールアドレス</label>
-                                  <input type="email" id="email" name="email" required class="w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out">
-                                </div>
-                              </div>
-                              <div class="p-2 w-1/2 mx-auto">
-                                <div class="relative">
-                                  <label for="password" class="leading-7 text-sm text-gray-600">パスワード</label>
-                                  <input type="password" id="password" name="password" required class="w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out">
-                                </div>
-                              </div>
-                              <div class="p-2 w-1/2 mx-auto">
-                                <div class="relative">
-                                  <label for="password_confirmation" class="leading-7 text-sm text-gray-600">パスワード確認</label>
-                                  <input type="password_confirmation" id="password_confirmation" name="password_confirmation" required class="w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out">
-                                </div>
-                              </div>
-                              <div class="p-2 w-full flex justify-around mt-4">
-                                <button onclick="location.href='{{ route('admin.owners.index')}}'" class="bg-gray-200 border-0 py-2 px-8 focus:outline-none hover:bg-igray-400 rounded text-lg">戻る</button>
-                                <button class="bg-indigo-500 border-0 py-2 px-8 focus:outline-none hover:bg-indigo-600 rounded text-lg">登録する</button>
-                              </div>
-                            </div>
-                        </div>
+                            </form>
+                          </div>
                     </section>
                 </div>
             </div>


### PR DESCRIPTION
## sec117 登録する処理 - CRUD(Store)
- 前回まではcreate画面でフォームを用意した。
- 今回は登録するボタンで登録処理を行う。
- Formタグ、method="post" action=store 指定
- @csrf 必須
- 戻るボタンは type="button"をつけておく
- inputタグ name="" 属性を
Request $request インスタンスで取得
dd($request->name);
- 保存する際にバリデーション機能を追加。
- 1. View
バリデーションで画面読み込み後も入力した値を保持したい場合
- <input name="email" value="{{ old('email') }}">
- 2. Model - プロパティで必要な情報を指定する必要がある。
$fillable or $guarded で設定
- procted $fillable = [
    'name',
    'email',
    'password',
];
- 3. Controller - バリデーション設定
簡易バリデーション or カスタムリクエスト
- $request->validate([
    'name' => 'required|string|max:255',
    'email' => 'required|string|email|max:255|unique:owners',
    'password' => 'required|string|confirmed|min:8',
]);
- 4. Controller - 保存処理
Owner::create([
    'name' => $request->name,
    'email' => $request->email,
    'password' => Hash::make($request->password),
]);
return redirect()->route('admin.owners.index'); 


laravel10でauth-validation-errorsが設定されてないため別途作成する必要がある（バリデーション）