### PR TITLE
ソフトデリート view画面作成(削除ボタン、クリック後ページ遷移)

### DIFF
--- a/umarche/MULTILOGIN.md
+++ b/umarche/MULTILOGIN.md
@@ -864,8 +864,56 @@ $owner->save();
 redirect()->route()->with();
 ```
 
+## sec121 Delete ソフトデリート
+1）論理削除（ソフトデリート）->復元できる（（ゴミ箱）
+2）物理削除（デリート）->復元できない
 
-1\.
+- マイグレーション側
+```
+$table->softDeletes();
+```
+
+- モデル側
+```
+use Illuminate\Database\Eloquent\SoftDeletes;
+```
+
+- モデルのクラス内
+```
+use SoftDeletes;
+```
+
+- コントローラ側
+```
+Owner::findOrFail($id)->delete(); // ソフトデリート
+Owner::all(); // ソフトデリートしたものは表示されない
+Owner::onlyTrashed()->get(); // ゴミ箱のみ表示
+Owner::withTrashed()->get(); // ゴミ箱も含め表示
+
+Owner::onlyTstashed()->restore(); // 復元
+Owner::onlyTrashed()->forceDelete(); // 完全削除
+
+$owner->trashed() // ソフトデリートされているかの確認
+```
+
+- Delete アラート表示（JS）
+```
+<form id="delete_{{$owner->id}}" method="post"
+action = "{{ route('admin.owners.destroy', ['owner' => $owner->id])}}">
+    @csrf @method('delete')
+<a href="#" data-id="{{ $owner->id }}" onclick="deletePost(this)">削除</a>
+
+<script>
+    function deletePost(e) {
+        'use strict';
+        if(confirm('本当に削除してもいいですか？')) {
+            document.getElementById('delete_' + e.dataset.id).submit();
+        }
+    }
+</script>
+```
+
+1\. view側を作成する
 ```
 ```
 

--- a/umarche/app/Http/Controllers/Admin/OwnersController.php
+++ b/umarche/app/Http/Controllers/Admin/OwnersController.php
@@ -112,6 +112,6 @@ class OwnersController extends Controller
      */
     public function destroy(string $id)
     {
-        //
+        dd('削除処理');
     }
 }

--- a/umarche/resources/views/admin/owners/index.blade.php
+++ b/umarche/resources/views/admin/owners/index.blade.php
@@ -23,6 +23,7 @@
                                   <th class="px-4 py-3 title-font tracking-wider font-medium text-gray-900 text-sm bg-gray-100">メールアドレス</th>
                                   <th class="px-4 py-3 title-font tracking-wider font-medium text-gray-900 text-sm bg-gray-100">作成日</th>
                                   <th class="px-4 py-3 title-font tracking-wider font-medium text-gray-900 text-sm bg-gray-100 rounded-tr rounded-br"></th>
+                                  <th class="px-4 py-3 title-font tracking-wider font-medium text-gray-900 text-sm bg-gray-100 rounded-tr rounded-br"></th>
                                 </tr>
                               </thead>
                               <tbody>
@@ -33,6 +34,13 @@
                                   <td class="px-4 py-3">
                                     <button onclick="location.href='{{ route('admin.owners.edit', ['owner' => $owner->id ])}}'" class="bg-indigo-400 border-0 py-2 px-4 focus:outline-none hover:bg-indigo-500 rounded">編集</button>
                                   </td>
+                                  <form id="delete_{{$owner->id}}" method="post" action="{{ route('admin.owners.destroy', ['owner' => $owner->id ] )}}">
+                                    @csrf
+                                    @method('delete')
+                                    <td class="px-4 py-3">
+                                      <a href="#" data-id="{{ $owner->id }}" onclick="deletePost(this)" class="bg-red-400 border-0 py-2 px-4 focus:outline-none hover:bg-red-500 rounded">削除</button>
+                                    </td>
+                                  </form>
                                 </tr>
                                 @endforeach
                               </tbody>
@@ -56,4 +64,12 @@
             </div>
         </div>
     </div>
+<script>
+  function deletePost(e) {
+      'use strict';
+      if(confirm('本当に削除してもいいですか？')) {
+          document.getElementById('delete_' + e.dataset.id).submit();
+      }
+  }
+</script>
 </x-app-layout>


### PR DESCRIPTION

## sec121 Delete ソフトデリート
1）論理削除（ソフトデリート）->復元できる（（ゴミ箱）
2）物理削除（デリート）->復元できない

- マイグレーション側
```
$table->softDeletes();
```

- モデル側
```
use Illuminate\Database\Eloquent\SoftDeletes;
```

- モデルのクラス内
```
use SoftDeletes;
```

- コントローラ側
```
Owner::findOrFail($id)->delete(); // ソフトデリート
Owner::all(); // ソフトデリートしたものは表示されない
Owner::onlyTrashed()->get(); // ゴミ箱のみ表示
Owner::withTrashed()->get(); // ゴミ箱も含め表示

Owner::onlyTstashed()->restore(); // 復元
Owner::onlyTrashed()->forceDelete(); // 完全削除

$owner->trashed() // ソフトデリートされているかの確認
```

- Delete アラート表示（JS）
```
<form id="delete_{{$owner->id}}" method="post"
action = "{{ route('admin.owners.destroy', ['owner' => $owner->id])}}">
    @csrf @method('delete')
<a href="#" data-id="{{ $owner->id }}" onclick="deletePost(this)">削除</a>

<script>
    function deletePost(e) {
        'use strict';
        if(confirm('本当に削除してもいいですか？')) {
            document.getElementById('delete_' + e.dataset.id).submit();
        }
    }
</script>
```