### PR TITLE
shopの削除　カスケード

### DIFF
--- a/umarche/2_OWNER.md
+++ b/umarche/2_OWNER.md
@@ -193,3 +193,12 @@ try {
     throw $e;
 }
 ```
+
+## sec203 Shopの削除　カスケード
+- Owner->shop と外部キー制約を設定しているため追加設定が必要。
+```
+$table->foreignId('owner_id')
+    ->constrained()
+    ->onUpdate('cascade')
+    ->onDelete('cascade');
+```

--- a/umarche/database/migrations/2024_06_14_231148_create_shops_table.php
+++ b/umarche/database/migrations/2024_06_14_231148_create_shops_table.php
@@ -13,7 +13,10 @@ return new class extends Migration
     {
         Schema::create('shops', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('owner_id')->constrained();
+            $table->foreignId('owner_id')
+            ->constrained()
+            ->onUpdate('cascade')
+            ->onDelete('cascade');
             $table->string('name');
             $table->text('information');
             $table->string('filename');


### PR DESCRIPTION
## sec203 Shopの削除　カスケード
- 完全に削除ボタンをクリックしても外部キー制約のエラーが出てしまっていた。
- Owner->shop と外部キー制約を設定しているため追加設定が必要。
```
$table->foreignId('owner_id')
    ->constrained()
    ->onUpdate('cascade')
    ->onDelete('cascade');
```