### PR TITLE
Shop uploadImage resizeByUser

### DIFF
--- a/umarche/2_OWNER.md
+++ b/umarche/2_OWNER.md
@@ -395,3 +395,33 @@ php artisan vendor:publish --tag=laravel-errors
 https://pixabay.com/ja/
 
 
+## sec208 画像アップロード
+### 画像アップロード
+- バリデーション->〇〇
+- 画像サイズ（1920px × 1080px (FullHD)）
+-> ①ユーザ側でリサイズしてもらう
+-> ②サーバー側でリサイズする
+ -> Intervention Imageを使う
+- 重複しないファイル名にて変更、保存
+
+### 画像アップロード　ビュー側
+- View側
+```
+<form method="post" action="" enctype="multipart/form-data">
+
+<input type="file" accept="image/png, image/jpeg, image/jpg">
+```
+
+### 画像アップロード　コントローラ側
+- リサイズしないパターン（putFileでファイル名生成）
+```
+use Illuminate\Support\Facades\Storage;
+
+public function update(Request $request, $id)
+    {
+        $imageFile = $request->image;
+        if(!is_null($imageFile) && $imageFile->isValid() ){
+            Storage::putFile('public/shops', $imageFile);
+        }
+    }
+```

--- a/umarche/app/Http/Controllers/Owner/ShopController.php
+++ b/umarche/app/Http/Controllers/Owner/ShopController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 Use illuminate\Support\Facades\Auth;
 use App\Models\Shop;
+use Illuminate\Support\Facades\Storage;
 
 class ShopController extends Controller
 {
@@ -40,10 +41,17 @@ class ShopController extends Controller
 
     public function edit(string $id)
     {
-        dd(Shop::findOrFail($id));
+        $shop = Shop::findOrFail($id);
+        // dd(Shop::findOrFail($id));
+        return view('owner.shops.edit' , compact('shop'));
     }
 
     public function update(Request $request, string $id)
     {
+        $imageFile = $request->image;
+        if(!is_null($imageFile) && $imageFile->isValid() ){
+            Storage::putFile('public/shops', $imageFile);
+        }
+        return redirect()->route('owner.shops.index');
     }
 }

--- a/umarche/resources/views/owner/shops/edit.blade.php
+++ b/umarche/resources/views/owner/shops/edit.blade.php
@@ -9,7 +9,21 @@
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                 <div class="p-6 text-gray-900">
-                    {{ __("You're logged in!") }}
+                    <form method="post" action="{{ route('owner.shops.update', ['shop' => $shop->id ])}}" enctype="multipart/form-data">
+                        @csrf
+                        <div class="-m-2">
+                            <div class="p-2 w-1/2 mx-auto">
+                                <div class="relative">
+                                <label for="image" class="leading-7 text-sm text-gray-600">画像</label>
+                                <input type="file" id="image" name="image" accept="image/png, image/jpeg, image/jpg" class="w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out">
+                                </div>
+                            </div>
+                        </div>
+                        <div class="p-2 w-full flex justify-around mt-4">
+                            <button type="button" onclick="location.href='{{ route('owner.shops.index')}}'" class="bg-gray-200 border-0 py-2 px-8 focus:outline-none hover:bg-igray-400 rounded text-lg">戻る</button>
+                            <button type="submit" class="bg-indigo-500 border-0 py-2 px-8 focus:outline-none hover:bg-indigo-600 rounded text-lg">更新する</button>
+                        </div>
+                    </form>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## sec208 画像アップロード
### 画像アップロード
- バリデーション->〇〇
- 画像サイズ（1920px × 1080px (FullHD)）
-> ①ユーザ側でリサイズしてもらう
-> ②サーバー側でリサイズする
 -> Intervention Imageを使う
- 重複しないファイル名にて変更、保存

### 画像アップロード　ビュー側
- View側
```
<form method="post" action="" enctype="multipart/form-data">

<input type="file" accept="image/png, image/jpeg, image/jpg">
```

### 画像アップロード コントローラ側
- リサイズしないパターン（putFileでファイル名生成）
```
use Illuminate\Support\Facades\Storage;

public function update(Request $request, $id)
    {
        $imageFile = $request->image;
        if(!is_null($imageFile) && $imageFile->isValid() ){
            Storage::putFile('public/shops', $imageFile);
        }
    }
```