### PR TITLE
Shop サービスへの切り離し、コードの重複防止

### DIFF
--- a/umarche/2_OWNER.md
+++ b/umarche/2_OWNER.md
@@ -459,3 +459,45 @@ public function messages()
     ];
 }
 ```
+
+## sec210 サービスへの切り離し
+### サービスへの切り離し
+- フォルダ作成
+```
+cd app
+mkdir Services
+cd Services
+touch ImageService.php
+```
+
+- app/Http/Controllers/Owner/ShopController.php の
+update関数で記述していたコードを丸ごと下記ディレクトリへ
+- app/Services/ImageService.php
+```
+<?php
+
+namespace App\Services;
+use Illuminate\Support\Facades\Storage;
+
+class ImageService
+{
+    public static function upload($imageFile, $folderName) {
+
+        $fileName = uniqid(rand().'_');
+        $extension = $imageFile->extension();
+        $fileNameToStore = $fileName. '.' . $extension;
+        Storage::put('public/' . $folderName . '/' .$fileNameToStore, $imageFile );
+
+        return $fileNameToStore;
+    }
+}
+```
+
+- ShopControllerにImageService.phpで定義したコードを適用する
+```
+use App\Services\ImageService;
+
+$fileNameToStore = ImageService::upload($imageFile, 'shops');
+```
+
+- これによりコードの重複もなくなり、関数内の処理も整理される。

--- a/umarche/app/Http/Controllers/Owner/ShopController.php
+++ b/umarche/app/Http/Controllers/Owner/ShopController.php
@@ -8,6 +8,7 @@ use illuminate\Support\Facades\Auth;
 use App\Models\Shop;
 use Illuminate\Support\Facades\Storage;
 use App\Http\Requests\UploadImageRequest;
+use App\Services\ImageService;
 
 class ShopController extends Controller
 {
@@ -50,10 +51,15 @@ class ShopController extends Controller
     public function update(UploadImageRequest $request, string $id)
     {
         // バリデーションが通った後の処理
-        $validated = $request->validated();
         $imageFile = $request->image;
         if(!is_null($imageFile) && $imageFile->isValid() ){
-            Storage::putFile('public/shops', $imageFile);
+            $fileNameToStore = ImageService::upload($imageFile, 'shops');
+            // Storage::putFile('public/shops', $imageFile);
+            // $fileName = uniqid(rand().'_');
+            // $extension = $imageFile->extension();
+            // $fileNameToStore = $fileName. '.' . $extension;
+
+            // Storage::put('public/shops/' .$fileNameToStore, $imageFile );
         }
         return redirect()->route('owner.shops.index')->with('success', '更新されました。');
     }

--- a/umarche/app/Services/ImageService.php
+++ b/umarche/app/Services/ImageService.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Services;
+use Illuminate\Support\Facades\Storage;
+
+class ImageService
+{
+    public static function upload($imageFile, $folderName) {
+
+        $fileName = uniqid(rand().'_');
+        $extension = $imageFile->extension();
+        $fileNameToStore = $fileName. '.' . $extension;
+        Storage::put('public/' . $folderName . '/' .$fileNameToStore, $imageFile );
+
+        return $fileNameToStore;
+    }
+}


### PR DESCRIPTION
## sec210 サービスへの切り離し
### サービスへの切り離し
- フォルダ作成
```
cd app
mkdir Services
cd Services
touch ImageService.php
```

- app/Http/Controllers/Owner/ShopController.php の
update関数で記述していたコードを丸ごと下記ディレクトリへ
- app/Services/ImageService.php
```
<?php

namespace App\Services;
use Illuminate\Support\Facades\Storage;

class ImageService
{
    public static function upload($imageFile, $folderName) {

        $fileName = uniqid(rand().'_');
        $extension = $imageFile->extension();
        $fileNameToStore = $fileName. '.' . $extension;
        Storage::put('public/' . $folderName . '/' .$fileNameToStore, $imageFile );

        return $fileNameToStore;
    }
}
```

- ShopControllerにImageService.phpで定義したコードを適用する
```
use App\Services\ImageService;

$fileNameToStore = ImageService::upload($imageFile, 'shops');
```

- これによりコードの重複もなくなり、関数内の処理も整理される。