### PR TITLE
imageのIndex, モデル、リレーション設定、ダッシュボード「画像管理」追加

### DIFF
--- a/umarche/2_OWNER.md
+++ b/umarche/2_OWNER.md
@@ -566,3 +566,24 @@ ImageController::class)
 ->middleware('auth:owners')->except('show');
 ```
 
+## sec214 ImageのIndex
+- コントローラ
+（constructはShopControllerを参考に）
+
+```
+public function index()
+{
+    $images = Image::where('owner_id', Auth::id())
+    ->orderby('updated_at', 'desc') // 降順(小さくなる)
+    ->paginate(20);
+
+    以下略
+}
+```
+
+- ビュー
+（shops/index.blade.phpを参考に）
+- コンポーネントをまとめるために変更
+```
+<x-thumbnail 略 type="products" />
+```

--- a/umarche/app/Http/Controllers/Owner/ImageController.php
+++ b/umarche/app/Http/Controllers/Owner/ImageController.php
@@ -4,15 +4,37 @@ namespace App\Http\Controllers\Owner;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
+use App\Models\Image;
+use Illuminate\Support\Facades\Auth;
 
 class ImageController extends Controller
 {
-    /**
-     * Display a listing of the resource.
-     */
+
+    public function __construct()
+    {
+        $this->middleware('auth:owners');
+
+        $this->middleware(function ($request, $next) {
+            $id = $request->route()->parameter('image'); // imageのid取得
+            if(!is_null($id)) { //null判定
+                $imagesOwnerId = Image::findOrFail($id)->owner->id;
+                $imageId = (int)$imagesOwnerId; // キャスト　文字列→数値に型変換
+                if($imageId !== Auth::id()) { // 同じでなかったら
+                    abort(404);
+                }
+            }
+            return $next($request);
+        });
+    }
+
     public function index()
     {
-        //
+        $images = Image::where('owner_id', Auth::id())
+        ->orderBy('updated_at', 'desc')
+        ->paginate(20);
+
+        return view('owner.images.index',
+        compact('images'));
     }
 
     /**

--- a/umarche/app/Http/Controllers/Owner/ShopController.php
+++ b/umarche/app/Http/Controllers/Owner/ShopController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers\Owner;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
-use illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Auth;
 use App\Models\Shop;
 use Illuminate\Support\Facades\Storage;
 use App\Http\Requests\UploadImageRequest;

--- a/umarche/app/Models/Image.php
+++ b/umarche/app/Models/Image.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use App\Models\Owner;
 
 class Image extends Model
 {
@@ -14,4 +15,8 @@ class Image extends Model
         'filename'
     ];
 
+    public function owner()
+    {
+        return $this->belongsTo(Owner::class);
+    }
 }

--- a/umarche/app/Models/Owner.php
+++ b/umarche/app/Models/Owner.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use App\Models\Shop;
+use App\Models\Image;
 
 class Owner extends Authenticatable
 {
@@ -46,5 +47,10 @@ class Owner extends Authenticatable
     public function shop()
     {
         return $this->hasOne(Shop::class);
+    }
+
+    public function image()
+    {
+        return $this->hasMany(Image::class);
     }
 }

--- a/umarche/resources/views/components/shop-thumbnail.blade.php
+++ b/umarche/resources/views/components/shop-thumbnail.blade.php
@@ -1,7 +1,0 @@
-<div>
-    @if(empty($filename))
-        <img src="{{ asset('images/no_image.png')}}">
-    @else
-        <img src="{{ asset('storage/shops/' . $filename)}}">
-    @endif
-</div>

--- a/umarche/resources/views/components/thumbnail.blade.php
+++ b/umarche/resources/views/components/thumbnail.blade.php
@@ -1,0 +1,18 @@
+@php
+    if($type === 'shops'){
+        $path = 'storage/shops/';
+    }
+    if($type === 'products'){
+        $path = 'storage/products/';
+    }
+
+@endphp
+
+
+<div>
+    @if(empty($filename))
+        <img src="{{ asset('images/no_image.png')}}">
+    @else
+        <img src="{{ asset($path . $filename)}}">
+    @endif
+</div>

--- a/umarche/resources/views/layouts/owner-navigation.blade.php
+++ b/umarche/resources/views/layouts/owner-navigation.blade.php
@@ -20,6 +20,9 @@
                     <x-nav-link :href="route('owner.shops.index')" :active="request()->routeIs('owner.shops.index')">
                         店舗情報
                     </x-nav-link>
+                    <x-nav-link :href="route('owner.images.index')" :active="request()->routeIs('owner.images.index')">
+                        画像管理
+                    </x-nav-link>
                 </div>
             </div>
 
@@ -77,6 +80,9 @@
             </x-responsive-nav-link>
             <x-responsive-nav-link :href="route('owner.shops.index')" :active="request()->routeIs('owner.shops.index')">
                 店舗情報
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('owner.images.index')" :active="request()->routeIs('owner.images.index')">
+                画像管理
             </x-responsive-nav-link>
         </div>
 

--- a/umarche/resources/views/owner/images/index.blade.php
+++ b/umarche/resources/views/owner/images/index.blade.php
@@ -1,0 +1,32 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Dashboard') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900">
+                    <x-flash-message status="session('status')" />
+                        <div class="flex justify-end mb-4">
+                            <button onclick="location.href='{{ route('owner.images.create')}}'" class="bg-indigo-500 border-0 py-2 px-8 focus:outline-none hover:bg-indigo-600 rounded text-lg">新規登録する</button>
+                        </div>
+                        @foreach ($images as $image)
+                            <div class="w-1/4 p-4">
+                                <a href="{{ route('owner.images.edit', ['image' => $image->id ])}}">
+                                    <div class="border rounded-md p-4">
+                                            <div class="text-xl">{{ $image->title }}</div>
+                                            <x-thumbnail :filename="$shop->filename" type="product" />
+                                        </div>
+                                    </div>
+                                </a>
+                            </div>
+                        @endforeach
+                        {{ $images->links() }}
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/umarche/resources/views/owner/shops/edit.blade.php
+++ b/umarche/resources/views/owner/shops/edit.blade.php
@@ -38,7 +38,7 @@
                             <div class="p-2 w-1/2 mx-auto">
                                 <div class="relative">
                                     <div class="w-32">
-                                        <x-shop-thumbnail />
+                                        <x-thumbnail :filename="$shop->filename" type="shops" />
                                     </div>
                                 </div>
                             </div>

--- a/umarche/resources/views/owner/shops/index.blade.php
+++ b/umarche/resources/views/owner/shops/index.blade.php
@@ -22,7 +22,7 @@
                                         @endif
                                     </div>
                                         <div class="text-xl">{{ $shop->name }}</div>
-                                        <x-shop-thumbnail :filename="$shop->filename" />
+                                        <x-thumbnail :filename="$shop->filename" type="shops" />
                                     </div>
                                 </div>
                             </a>


### PR DESCRIPTION
## sec214 ImageのIndex
- コントローラ
（constructはShopControllerを参考に）

```
public function index()
{
    $images = Image::where('owner_id', Auth::id())
    ->orderby('updated_at', 'desc') // 降順(小さくなる)
    ->paginate(20);

    以下略
}
```

- ビュー
（shops/index.blade.phpを参考に）
- コンポーネントをまとめるために変更
```
<x-thumbnail 略 type="products" />
```