### PR TITLE
Image Create(画像複数アップロード設定前準備)とバリデーション設定

### DIFF
--- a/umarche/2_OWNER.md
+++ b/umarche/2_OWNER.md
@@ -587,3 +587,26 @@ public function index()
 ```
 <x-thumbnail 略 type="products" />
 ```
+
+## sec215 ImageのCreate, バリデーション Store
+
+### ImageのCreate と バリデーション
+（Shops/edit.blade.phpを参考に）
+
+- 画像の複数アップロード対応
+```
+<input type="file" name="files[][image]" multiple 略>
+```
+
+- フォームリクエストのrulesに下記を追加
+App/Http/Requests/UploadImageRequest.php
+
+```
+'files.*.image' => 'required|image|mimes:jpg.jpeg.png|max:2048',
+```
+https://readouble.com/laravel/10.x/ja/validation.html
+- 配列中の属性をバリデーションするために「ドット記法」が使える。
+
+
+
+

--- a/umarche/app/Http/Controllers/Owner/ImageController.php
+++ b/umarche/app/Http/Controllers/Owner/ImageController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Models\Image;
 use Illuminate\Support\Facades\Auth;
+use App\Http\Requests\UploadImageRequest;
 
 class ImageController extends Controller
 {
@@ -42,15 +43,15 @@ class ImageController extends Controller
      */
     public function create()
     {
-        //
+        return view('owner.images.create');
     }
 
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
+    public function store(UploadImageRequest $request)
     {
-        //
+        dd($request);
     }
 
     /**

--- a/umarche/app/Http/Requests/UploadImageRequest.php
+++ b/umarche/app/Http/Requests/UploadImageRequest.php
@@ -22,7 +22,8 @@ class UploadImageRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'image'=>'image|mimes:jpg,jpeg,png|max:2048',
+            'image' => 'image|mimes:jpg,jpeg,png|max:2048',
+            'files.*.images' => 'required|image|mimes:jpg,jpeg,png|max:2048'
         ];
     }
     

--- a/umarche/resources/views/owner/images/create.blade.php
+++ b/umarche/resources/views/owner/images/create.blade.php
@@ -1,0 +1,42 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Dashboard') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900">
+                     <!-- Validation Errors -->
+                     @if ($errors->any())
+                        <div class="mb-4">
+                            <ul class="list-disc list-inside text-sm text-red-600">
+                                @foreach ($errors->all() as $error)
+                                    <li>{{ $error }}</li>
+                                @endforeach
+                            </ul>
+                     </div>
+                     @endif
+                    <x-auth-validation-errors class="mb-4" :errors="$errors" />
+                    <form method="post" action="{{ route('owner.images.store', )}}" enctype="multipart/form-data">
+                        @csrf
+                        <div class="-m-2">
+                            <div class="p-2 w-1/2 mx-auto">
+                                <div class="relative">
+                                    <label for="image" class="leading-7 text-sm text-gray-600">画像</label>
+                                    <input type="file" id="image" name="files[][image]" multiple accept="image/png,image/jpeg,image/jpg" class="w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out">
+                                </div>
+                            </div>
+                        </div>
+                        <div class="p-2 w-full flex justify-around mt-4">
+                            <button type="button" onclick="location.href='{{ route('owner.images.index')}}'" class="bg-gray-200 border-0 py-2 px-8 focus:outline-none hover:bg-gray-400 rounded text-lg">戻る</button>
+                            <button type="submit" class="bg-indigo-500 border-0 py-2 px-8 focus:outline-none hover:bg-indigo-600 rounded text-lg">登録する</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>


### PR DESCRIPTION
## sec215 ImageのCreate, バリデーション Store

### ImageのCreate と バリデーション
（Shops/edit.blade.phpを参考に）

- 画像の複数アップロード対応
```
<input type="file" name="files[][image]" multiple 略>
```

- フォームリクエストのrulesに下記を追加
App/Http/Requests/UploadImageRequest.php

```
'files.*.image' => 'required|image|mimes:jpg.jpeg.png|max:2048',
```
https://readouble.com/laravel/10.x/ja/validation.html
- 配列中の属性をバリデーションするために「ドット記法」が使える。